### PR TITLE
patch for bliss-0.77 compatibility

### DIFF
--- a/sympol/symmetrygroupconstruction/graphconstructionbliss.cpp
+++ b/sympol/symmetrygroupconstruction/graphconstructionbliss.cpp
@@ -16,35 +16,6 @@ using namespace permlib;
 static LoggerPtr logger(Logger::getLogger("SymGraphB "));
 
 
-/// data structure used for the bliss callback
-struct BlissData {
-	unsigned int T;
-	std::list<Permutation::ptr> generators;
-};
-
-
-/// bliss callback for graph automorphism generators
-static
-void blisshook(
-	void*                 user_param,
-	unsigned int          n,
-	const unsigned int*   aut
-	)
-{
-	BOOST_ASSERT( user_param != 0 );
-	BlissData* bliss = reinterpret_cast<BlissData*>(user_param);
-	
-	BOOST_ASSERT( n % bliss->T == 0 );
-	Permutation::perm proj(n / bliss->T);
-	for (unsigned int i = 0; i < proj.size(); ++i) {
-		proj[i] = aut[i];
-		BOOST_ASSERT( aut[i] < proj.size() );
-	}
-	Permutation::ptr p(new Permutation(proj));
-	bliss->generators.push_back(p);
-}
-
-
 boost::shared_ptr<sympol::PermutationGroup> GraphConstructionBliss::compute(const MatrixConstruction* matrix) const {
 	const unsigned int T = static_cast<unsigned int>(std::ceil( log2((double) matrix->k() + 1.0) ));
 	const unsigned int matrixRows = matrix->dimension();
@@ -71,14 +42,29 @@ boost::shared_ptr<sympol::PermutationGroup> GraphConstructionBliss::compute(cons
 	YALLOG_DEBUG(logger, "start graph automorphism search with bliss");
 	
 	bliss::Stats stats;
-	BlissData data;
-	data.T = T;
+	std::list<Permutation::ptr> generators;
+
+	/// bliss callback for graph automorphism generators
+	auto blisshook = [T, &generators](
+		unsigned int n,
+		const unsigned int* aut
+		)
+	{
+		BOOST_ASSERT( n % T == 0 );
+		Permutation::perm proj(n / T);
+		for (unsigned int i = 0; i < proj.size(); ++i) {
+			proj[i] = aut[i];
+			BOOST_ASSERT( aut[i] < proj.size() );
+		}
+		Permutation::ptr p(new Permutation(proj));
+		generators.push_back(p);
+	};
 	/* Prefer splitting partition cells corresponding to nodes with color 0 or 1,
 	 * so that we obtain a group basis beginning with them. */
 	G.set_splitting_heuristic(bliss::Graph::shs_f);
 	// disable component recursion as advised by Tommi Junttila from bliss
 	G.set_component_recursion(false);
-	G.find_automorphisms(stats, blisshook, &data);
+	G.find_automorphisms(stats, blisshook);
 	if (yal::DEBUG <= yal::ReportLevel::get())
 		stats.print(stdout);
 	else 
@@ -103,12 +89,12 @@ boost::shared_ptr<sympol::PermutationGroup> GraphConstructionBliss::compute(cons
 	
 	KnownBSGSConstruction<PERMUTATION, TRANSVERSAL> bsgsSetup(matrixRows);
 	boost::shared_ptr<PermutationGroup> group(new PermutationGroup(
-		bsgsSetup.construct(data.generators.begin(), data.generators.end(), baseVars.begin(), baseVars.end())
+		bsgsSetup.construct(generators.begin(), generators.end(), baseVars.begin(), baseVars.end())
 	));
 #else
 	SchreierSimsConstruction<PERMUTATION, TRANSVERSAL> bsgsSetup(matrixRows);
 	boost::shared_ptr<PermutationGroup> group(new PermutationGroup(
-		bsgsSetup.construct(data.generators.begin(), data.generators.end())
+		bsgsSetup.construct(generators.begin(), generators.end())
 	));
 #endif
 


### PR DESCRIPTION
Since `bliss-0.75`, the function `bliss::AbstractGraph::find_automorphisms` [changed parameter](https://users.aalto.fi/~tjunttil/bliss/CHANGES.txt).

This patch replaces the original function-pointer-based hook by lambda expression to fix build.